### PR TITLE
Add self-hosted Qwen3-TTS (dd_tts) provider; retire ElevenLabs

### DIFF
--- a/.github/workflows/daily-news-digest.yml
+++ b/.github/workflows/daily-news-digest.yml
@@ -13,7 +13,7 @@ on:
         default: false
         type: boolean
       force_ai_regeneration:
-        description: 'Force regeneration (use current TTS config e.g. ElevenLabs); ignores existing today content'
+        description: 'Force regeneration (use current TTS config e.g. dd_tts / edge_tts); ignores existing today content'
         required: false
         default: false
         type: boolean
@@ -103,7 +103,9 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+      # Self-hosted DynamicDevices Qwen3-TTS (replaces ElevenLabs for en_GB + bella)
+      DD_TTS_URL: ${{ secrets.DD_TTS_URL }}
+      DD_TTS_TOKEN: ${{ secrets.DD_TTS_TOKEN }}
       DEBUG_MODE: ${{ github.event.inputs.debug_mode }}
     steps:
       - name: 📥 Checkout repository
@@ -118,11 +120,22 @@ jobs:
           LANG="${{ matrix.language }}"
           FORCE_ARG=""
           [[ "${{ inputs.force_ai_regeneration }}" == "true" ]] && FORCE_ARG="--force-regenerate"
+          # en_GB + bella use the self-hosted Qwen3-TTS (dd_tts) per voice_config.json.
+          # Health preflight: if the box is unreachable, fall back to edge_tts so the
+          # daily accessibility digest still ships rather than failing the build.
           TTS_ARG=""
-          [[ "$LANG" == "en_GB" ]] && TTS_ARG="--tts-provider elevenlabs"
-          [[ "$LANG" == "bella" ]] && TTS_ARG="--tts-provider elevenlabs"
+          case "$LANG" in
+            en_GB|bella)
+              if [[ -n "$DD_TTS_URL" ]] && curl -sf -m 10 "${DD_TTS_URL%/}/health" >/dev/null 2>&1; then
+                echo "✅ dd_tts endpoint healthy for $LANG (config selects dd_tts)"
+              else
+                echo "::warning title=dd_tts unavailable::TTS endpoint failed health preflight; falling back to edge_tts for $LANG"
+                TTS_ARG="--tts-provider edge_tts"
+              fi
+              ;;
+          esac
           echo "▶ Generating $LANG..."
-          timeout 300 python scripts/github_ai_news_digest.py --language "$LANG" $TTS_ARG $FORCE_ARG
+          timeout 600 python scripts/github_ai_news_digest.py --language "$LANG" $TTS_ARG $FORCE_ARG
           TODAY=$(date +%Y_%m_%d)
           AUDIO="docs/${LANG}/audio/news_digest_ai_${TODAY}.mp3"
           TEXT="docs/${LANG}/news_digest_ai_${TODAY}.txt"

--- a/config/voice_config.json
+++ b/config/voice_config.json
@@ -6,7 +6,8 @@
       "language": "English (Ireland)",
       "gender": "Female",
       "provider": "Edge TTS",
-      "tts_provider": "elevenlabs",
+      "tts_provider": "dd_tts",
+      "dd_style": "neutral",
       "pocket_voice": "alba",
       "elevenlabs_voice_id": "8UiZmugqRl2JWvkN3NrW"
     },
@@ -74,7 +75,7 @@
       "language": "Polish (Poland)",
       "gender": "Female",
       "provider": "Edge TTS",
-      "tts_provider": "elevenlabs",
+      "tts_provider": "edge_tts",
       "pocket_voice": "alba",
       "elevenlabs_voice_id": "DTZOFDiEo6RpVklQfFpj"
     },
@@ -84,7 +85,8 @@
       "language": "English (Ireland) - Business/Finance",
       "gender": "Female",
       "provider": "Edge TTS",
-      "tts_provider": "elevenlabs",
+      "tts_provider": "dd_tts",
+      "dd_style": "neutral",
       "pocket_voice": "alba",
       "elevenlabs_voice_id": "EQu48Nbp4OqDxsnYh27f"
     }
@@ -115,10 +117,18 @@
       "output_format": "mp3_44100_128",
       "chunk_size": 4500
     },
+    "dd_tts": {
+      "style": "neutral",
+      "seed": 2,
+      "speed": null,
+      "paragraph_pause": null,
+      "request_timeout_s": 600,
+      "note": "Self-hosted DynamicDevices Qwen3-TTS. Endpoint DD_TTS_URL + bearer DD_TTS_TOKEN from env. Returns WAV -> transcoded to MP3. Per-voice 'dd_style' overrides this default style."
+    },
     "fallback": {
-      "enabled": false,
-      "provider": "NONE - Voice quality is critical. Fail rather than degrade.",
-      "note": "We NEVER fall back to inferior voices. Edge TTS quality is non-negotiable."
+      "enabled": true,
+      "provider": "edge_tts",
+      "note": "CI only: if the self-hosted dd_tts endpoint fails its health preflight, the daily workflow falls back to edge_tts so the accessibility service still ships. ElevenLabs retired 2026-07."
     }
   },
   "audio_settings": {

--- a/digest/tts.py
+++ b/digest/tts.py
@@ -242,6 +242,84 @@ async def _generate_audio_elevenlabs(
                     pass
 
 
+async def _generate_audio_dd(
+    digest_text: str,
+    output_filename: str,
+    voice_config: dict,
+    language: Optional[str] = None,
+) -> None:
+    """Generate audio via the self-hosted DynamicDevices Qwen3-TTS service.
+
+    Endpoint + bearer token come from env (DD_TTS_URL, DD_TTS_TOKEN). The service
+    synthesises the whole digest (paragraph-splitting internally) and returns WAV,
+    which we transcode to MP3 with pydub.
+    """
+    base_url = (os.getenv("DD_TTS_URL") or "").strip().rstrip("/")
+    if not base_url:
+        raise ValueError(
+            "DD_TTS_URL environment variable is not set. "
+            "Set it to the TTS endpoint, e.g. https://tts.dynamicdevices.co.uk"
+        )
+    if not aiohttp:
+        raise ImportError("aiohttp is required for DynamicDevices TTS")
+    token = (os.getenv("DD_TTS_TOKEN") or "").strip()
+    settings = voice_config.get("tts_settings", {}).get("dd_tts", {})
+    voice_cfg = voice_config.get("voices", {}).get(language or "", {})
+    style = voice_cfg.get("dd_style") or settings.get("style", "neutral")
+    seed = settings.get("seed", 2)
+    speed = settings.get("speed")  # None -> service uses per-style default
+    paragraph_pause = settings.get("paragraph_pause")  # None -> service default
+    timeout_s = settings.get("request_timeout_s", 600)
+
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    text = digest_text.strip()
+    if not text:
+        raise ValueError("Digest text is empty")
+    payload = {"text": text, "style": style, "seed": seed}
+    if speed is not None:
+        payload["speed"] = speed
+    if paragraph_pause is not None:
+        payload["paragraph_pause"] = paragraph_pause
+
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(f"{base_url}/tts", json=payload, headers=headers) as resp:
+            if resp.status == 401:
+                raise RuntimeError("DD TTS auth failed (401) - check DD_TTS_TOKEN")
+            resp.raise_for_status()
+            meta = await resp.json()
+        got_style = meta.get("style")
+        if got_style and got_style != style:
+            # Boundary guard: the service silently falls back to 'neutral' when a
+            # requested reference is missing. Surface a mismatch loudly rather than
+            # shipping the wrong voice unnoticed.
+            print(f"   ⚠️ DD TTS returned style '{got_style}' (requested '{style}')")
+        name = meta.get("name")
+        audio_url = meta.get("url") or (f"/audio/{name}" if name else None)
+        if not audio_url:
+            raise RuntimeError(f"DD TTS response missing audio reference: {meta}")
+        async with session.get(f"{base_url}{audio_url}", headers=headers) as aresp:
+            aresp.raise_for_status()
+            wav_bytes = await aresp.read()
+
+    fd, wav_path = tempfile.mkstemp(suffix="_dd.wav")
+    os.close(fd)
+    try:
+        with open(wav_path, "wb") as f:
+            f.write(wav_bytes)
+        from pydub import AudioSegment
+        audio = AudioSegment.from_wav(wav_path)
+        audio.export(output_filename, format="mp3", bitrate="192k")
+    finally:
+        try:
+            os.unlink(wav_path)
+        except OSError:
+            pass
+
+
 async def generate_audio_digest(
     digest_text: str,
     output_filename: str,
@@ -260,6 +338,8 @@ async def generate_audio_digest(
     print(f"\n🎤 Generating AI-enhanced audio: {output_filename} (provider: {tts_provider})")
     if tts_provider == "elevenlabs":
         print("   🔊 Using ElevenLabs TTS (voice_id from config)")
+    elif tts_provider == "dd_tts":
+        print("   🔊 Using DynamicDevices Qwen3-TTS (self-hosted)")
     elif tts_provider == "edge_tts":
         print("   🔊 Using Edge TTS")
     os.makedirs(os.path.dirname(output_filename), exist_ok=True)
@@ -281,6 +361,9 @@ async def generate_audio_digest(
         vid = elevenlabs_voice_id or voice_config.get("tts_settings", {}).get("elevenlabs", {}).get("voice_id") or "EXAVITQu4vr4xnSDxMaL"
         await _generate_audio_elevenlabs(digest_text, output_filename, vid, voice_config)
         print("   ✅ ElevenLabs audio generated successfully")
+    elif tts_provider == "dd_tts":
+        await _generate_audio_dd(digest_text, output_filename, voice_config, language)
+        print("   ✅ DynamicDevices Qwen3-TTS audio generated successfully")
     else:
         # Edge TTS
         tts_settings = voice_config["tts_settings"]["edge_tts"]

--- a/scripts/github_ai_news_digest.py
+++ b/scripts/github_ai_news_digest.py
@@ -58,7 +58,7 @@ class GitHubAINewsDigest:
         self.voice_name = self.config["voice"]
         voice_cfg = VOICE_CONFIG.get("voices", {}).get(language, {})
         self.tts_provider = (tts_provider_override or voice_cfg.get("tts_provider") or "edge_tts").lower()
-        if self.tts_provider not in ("edge_tts", "pocket_tts", "elevenlabs"):
+        if self.tts_provider not in ("edge_tts", "pocket_tts", "elevenlabs", "dd_tts"):
             self.tts_provider = "edge_tts"
         self.pocket_voice = voice_cfg.get("pocket_voice") or VOICE_CONFIG.get("tts_settings", {}).get("pocket_tts", {}).get("voice") or "alba"
         self.elevenlabs_voice_id = (
@@ -111,7 +111,7 @@ class GitHubAINewsDigest:
                 )
             print(f"\n📄 Using existing transcript (no API): {text_filename}")
             digest_text = tts_module.parse_existing_transcript(text_filename)
-            if self.tts_provider in ("pocket_tts", "elevenlabs"):
+            if self.tts_provider in ("pocket_tts", "elevenlabs", "dd_tts"):
                 digest_text = tts_module.reverse_edge_tts_edits(digest_text)
                 print(f"   📝 Using unedited text for {self.tts_provider} (Edge TTS edits reversed)")
             os.makedirs(os.path.dirname(audio_filename), exist_ok=True)
@@ -239,7 +239,7 @@ async def main() -> None:
     )
     parser.add_argument(
         "--tts-provider",
-        choices=["edge_tts", "pocket_tts", "elevenlabs"],
+        choices=["edge_tts", "pocket_tts", "elevenlabs", "dd_tts"],
         default=None,
         help="TTS provider override (default: use per-language config)",
     )


### PR DESCRIPTION
## Summary
- Replaces **ElevenLabs** with the **self-hosted DynamicDevices Qwen3-TTS** service for `en_GB` and `bella` digests (ElevenLabs subscription retired). `pl_PL` moves off ElevenLabs to its `edge_tts` Polish voice (`pl-PL-ZofiaNeural`).
- New `dd_tts` provider in `digest/tts.py`: POSTs to `DD_TTS_URL/tts` with a bearer token (`DD_TTS_TOKEN`), fetches the WAV from `/audio`, transcodes to MP3 via pydub. Honours a per-voice `dd_style` (falls back to the global default) and warns if the service returns a different style than requested (boundary guard).
- Daily workflow: passes `DD_TTS_URL`/`DD_TTS_TOKEN`, runs a **health preflight** before generation and **falls back to `edge_tts`** automatically if the self-hosted box is unreachable — so the accessibility digest still ships rather than failing the build. Drops `ELEVENLABS_API_KEY`; generation timeout bumped 300→600s.

## Endpoint / secrets (already configured)
- Endpoint: `https://tts.dynamicdevices.co.uk` (Cloudflare tunnel → on-box `:8200`, bearer-gated; `/health` open for the preflight).
- Repo secrets set: `DD_TTS_URL`, `DD_TTS_TOKEN`.

## Test plan
- [x] `voice_config.json` valid; `digest/tts.py` + `scripts/github_ai_news_digest.py` compile.
- [x] Local end-to-end via the real `generate_audio_digest(tts_provider="dd_tts", language="en_GB")` against the live endpoint → valid MP3 produced.
- [x] Endpoint auth verified: `/tts` + `/audio` return 401 without token, 200 with; `/health` open.
- [ ] Manual `workflow_dispatch` (publishes to production `audionews.uk`) — left for maintainer to trigger.
- [ ] Confirm `edge_tts` fallback path when the box is offline.

🤖 Prepared via Cursor on behalf of Alex Lennon.

Made with [Cursor](https://cursor.com)